### PR TITLE
Add file names to verbose output

### DIFF
--- a/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
+++ b/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
@@ -42,6 +42,18 @@ public class FastStrategy: Strategy {
                 usageCount: usageCounts[type] ?? 0
             )
         }
+
+        if verbose {
+            for type in types {
+                guard let files = fileCounts[type] else { continue }
+
+                print("\(type) used in the following files:")
+                for file in files.map({ "  \($0.pathString)" }) {
+                    print(file)
+                }
+            }
+        }
+
         return typeUsages
     }
 

--- a/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
+++ b/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
@@ -48,9 +48,9 @@ public class FastStrategy: Strategy {
                 guard let files = fileCounts[type] else { continue }
 
                 print("\(type) used in the following files:")
-                for file in files.map({ "  \($0.pathString)" }) {
-                    print(file)
-                }
+                files
+                    .map({  " \($0.pathString)" })
+                    .forEach { print($0) }
             }
         }
 


### PR DESCRIPTION
When `--verbose` flag is set, prints a section like:
```
Button used in the following files:
  /Users/kevinb/projects/MyCoolProject/Foo.swift
  /Users/kevinb/projects/MyCoolProject/Bar.swift
```
to make it easy to easy not just how many files use the type, but specifically which ones.