### PR TITLE
Add --includeTypeInheritance argument

### DIFF
--- a/Sources/SwiftTypeAdoptionReporter/Strategy.swift
+++ b/Sources/SwiftTypeAdoptionReporter/Strategy.swift
@@ -21,5 +21,9 @@ public struct TypeUsage {
 }
 
 public protocol Strategy: AnyObject {
+    /// A Boolean value indicating whether the strategy should include subclass declaration
+    /// and protocol conformance in usage counts.
+    var includeTypeInheritance: Bool { get set }
+
     func findUsageCounts() throws -> [String: TypeUsage]
 }

--- a/Sources/swift-type-adoption-reporter/main.swift
+++ b/Sources/swift-type-adoption-reporter/main.swift
@@ -37,6 +37,12 @@ let moduleNameArgument = argumentParser.add(
     usage: "Name of module containing types, to ensure types referenced by <module name>.<type name> are counted"
 )
 
+let includeTypeInheritanceArgument = argumentParser.add(
+    option: "--includeTypeInheritance",
+    kind: Bool.self,
+    usage: "If true, include subclass and protocol conformance declarations in usage counts"
+)
+
 let formatArgument = argumentParser.add(
     option: "--format",
     shortName: "-f",
@@ -69,6 +75,7 @@ do {
     }
 
     let moduleName = parsedArguments.get(moduleNameArgument)
+    let includeTypeInheritance = parsedArguments.get(includeTypeInheritanceArgument) ?? false
     let verbose = parsedArguments.get(verboseArgument) ?? false
 
     guard let paths = parsedArguments.get(pathsArgument) else {
@@ -82,6 +89,7 @@ do {
         paths: paths.map({ $0.path }),
         verbose: verbose
     )
+    strategy.includeTypeInheritance = includeTypeInheritance
 
     let formatter: ReportFormatter
     switch parsedArguments.get(formatArgument) {


### PR DESCRIPTION
Support including subclass declaration and protocol conformance in
usage counts by supplying the --includeTypeInheritance argument
to the CLI or setting the includeTypeInheritance property on the
Strategy from the Swift interface.