### PR TITLE
Add SwiftLint and SwiftFormat to CI checks

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,63 @@
+--disable fileHeader
+--disable isEmpty # Has the potential to auto-fix in a way that breaks the code
+--disable unusedArguments # We don't see enough value in the consistency this rule gives, and it could introduce conflicts in dependent PRs
+
+# These are potentially controversial.
+--disable blankLinesAroundMark # Is it a net improvement in code quality to enable this?
+--disable redundantLetError # Do we want to rely on implicit stuff?
+--disable redundantRawValues # It can be preferable to have all the cases values be explicit
+--disable redundantSelf # It can be preferable to have a consistent usage of self, e.g. in an init()
+--disable trailingClosures # Maybe we want to leave this up to stylistic preference? It was changing a lot of code
+
+--enable andOperator # Use of a comma instead of && is considered idiomatic Swift
+--enable anyObjectProtocol # `AnyObject` and `class` constraints are identical in function, but `class` is due to be deprecated
+--enable blankLinesAtEndOfScope
+--enable blankLinesAtStartOfScope
+--enable blankLinesBetweenScopes
+--enable braces
+--enable consecutiveBlankLines
+--enable consecutiveSpaces
+--enable duplicateImports
+--enable elseOnSameLine
+--enable emptyBraces
+--enable hoistPatternLet
+--enable indent
+--enable leadingDelimiters
+--enable linebreakAtEndOfFile
+--enable linebreaks
+--enable redundantBackticks
+--enable redundantBreak
+--enable redundantExtensionACL
+--enable redundantFileprivate
+--enable redundantGet
+--enable redundantInit
+--enable redundantLet
+--enable redundantNilInit
+--enable redundantObjc
+--enable redundantParens
+--enable redundantPattern
+--enable redundantReturn
+--enable redundantVoidReturnType
+--enable semicolons
+--enable sortedImports
+--enable spaceAroundBraces
+--enable spaceAroundBrackets
+--enable spaceAroundComments
+--enable spaceAroundGenerics
+--enable spaceAroundOperators
+--enable spaceAroundParens
+--enable spaceInsideBraces
+--enable spaceInsideBrackets
+--enable spaceInsideComments
+--enable spaceInsideGenerics
+--enable spaceInsideParens
+--enable specifiers
+--enable strongifiedSelf
+--enable todos
+--enable trailingCommas
+--enable trailingSpace
+--enable typeSugar
+--enable void
+--enable wrapArguments
+    --wrapcollections before-first
+--enable yodaConditions

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,87 @@
+disabled_rules:
+  - closure_parameter_position
+  - cyclomatic_complexity
+  - file_length
+  - force_cast
+  - function_body_length
+  - nesting
+  - todo
+  - type_body_length
+  - for_where
+  - no_fallthrough_only
+  # All the following Handled by SwiftFormat.
+  - closure_end_indentation
+  - closure_spacing
+  - explicit_init
+  - literal_expression_end_indentation
+  - operator_usage_whitespace
+  - private_over_fileprivate
+  - redundant_void_return
+  - return_arrow_whitespace
+  - trailing_comma
+  - vertical_parameter_alignment
+  - vertical_parameter_alignment_on_call
+  - vertical_whitespace
+  - implicit_return
+
+opt_in_rules:
+  - array_init
+  - block_based_kvo
+  - contains_over_filter_count
+  - contains_over_filter_is_empty
+  - contains_over_first_not_nil
+  - contains_over_range_nil_comparison
+  - discouraged_direct_init
+  - duplicate_imports
+  - empty_collection_literal
+  - empty_count
+  - empty_string
+  - empty_xctest_method
+  - extension_access_modifier
+  - fatal_error_message
+  - first_where
+  - flatmap_over_map_reduce
+  - force_unwrapping
+  - identical_operands
+  - implicit_return
+  - implicitly_unwrapped_optional
+  - joined_default_parameter
+  - multiline_parameters
+  - multiple_closures_with_trailing_closure
+  - nimble_operator
+  - overridden_super_call
+  - prefer_self_type_over_type_of_self
+  - private_unit_test
+  - prohibited_super_call
+  - protocol_property_accessors_order
+  - redundant_nil_coalescing
+  - redundant_set_access_control
+  - unneeded_parentheses_in_closure_argument
+
+analyzer_rules:
+  - unused_import
+  - unused_declaration
+
+indentation: 4
+
+weak_delegate: error
+
+function_parameter_count:
+  warning: 8
+  error: 8
+
+large_tuple:
+  warning: 3
+  error: 3
+
+identifier_name:
+  min_length: 0
+  max_length: 42
+
+type_name:
+  max_length: 52
+
+line_length: 200
+
+excluded:
+  - .build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ disabled_rules:
   - cyclomatic_complexity
   - file_length
   - force_cast
+  - force_try
   - function_body_length
   - nesting
   - todo
@@ -41,7 +42,6 @@ opt_in_rules:
   - fatal_error_message
   - first_where
   - flatmap_over_map_reduce
-  - force_unwrapping
   - identical_operands
   - implicit_return
   - implicitly_unwrapped_optional

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,10 @@ osx_image: xcode11.4
 branches:
   only:
   - master
+install:
+  - ./install_swiftlint.sh
+  - ./install_swiftformat.sh
 script:
-- set -o pipefail && swift test
+  - swiftlint lint --quiet
+  - swiftformat .
+  - set -o pipefail && swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ install:
   - ./install_swiftformat.sh
 script:
   - swiftlint lint --quiet
-  - swiftformat .
+  - swiftformat --lint .
   - set -o pipefail && swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ branches:
   only:
   - master
 install:
-  - ./install_swiftlint.sh
   - ./install_swiftformat.sh
 script:
-  - swiftlint lint --quiet
   - swiftformat .
   - set -o pipefail && swift test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ branches:
   only:
   - master
 install:
+  - ./install_swiftlint.sh
   - ./install_swiftformat.sh
 script:
+  - swiftlint lint --quiet
   - swiftformat .
   - set -o pipefail && swift test

--- a/Package.swift
+++ b/Package.swift
@@ -28,12 +28,15 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "swift-type-adoption-reporter",
-            dependencies: ["SwiftTypeAdoptionReporter"]),
+            dependencies: ["SwiftTypeAdoptionReporter"]
+        ),
         .target(
             name: "SwiftTypeAdoptionReporter",
-            dependencies: ["SwiftSyntax", "SwiftPM"]),
+            dependencies: ["SwiftSyntax", "SwiftPM"]
+        ),
         .testTarget(
             name: "SwiftTypeAdoptionReporterTests",
-            dependencies: ["SwiftTypeAdoptionReporter"]),
+            dependencies: ["SwiftTypeAdoptionReporter"]
+        ),
     ]
 )

--- a/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
+++ b/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
@@ -12,26 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TSCBasic
 import Foundation
 import SwiftSyntax
+import TSCBasic
 
 public class FastStrategy: SyntaxVisitor, Strategy {
     public var includeTypeInheritance: Bool = false
 
     public init(types: [String],
-         moduleName: String?,
-         paths: [AbsolutePath],
-         verbose: Bool = false) {
+                moduleName: String?,
+                paths: [AbsolutePath],
+                verbose: Bool = false) {
         self.types = types
         self.moduleName = moduleName
         self.paths = paths
         self.verbose = verbose
     }
 
-    public func findUsageCounts() throws -> [String : TypeUsage] {
+    public func findUsageCounts() throws -> [String: TypeUsage] {
         fileCounts = [:]
-        usageCounts  = [:]
+        usageCounts = [:]
 
         for path in paths {
             try visit(fileOrDirectory: path)
@@ -51,7 +51,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
 
                 print("\(type) used in the following files:")
                 files
-                    .map({  " \($0.pathString)" })
+                    .map({ " \($0.pathString)" })
                     .forEach { print($0) }
             }
         }
@@ -94,8 +94,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
                 if let moduleName = moduleName,
                     baseIdentifier == moduleName,
                     case let .identifier(identifier) = node.name.tokenKind,
-                    types.contains(identifier)
-                {
+                    types.contains(identifier) {
                     increment(identifier, token: node.name)
                     return .skipChildren
                 }
@@ -109,14 +108,12 @@ public class FastStrategy: SyntaxVisitor, Strategy {
                 case let .identifier(innerBaseIdentifier) = innerBaseIdentifierExpr.identifier.tokenKind,
                 innerBaseIdentifier == moduleName,
                 case let .identifier(innerIdentifier) = baseMemberAccessExpr.name.tokenKind,
-                types.contains(innerIdentifier)
-            {
+                types.contains(innerIdentifier) {
                 increment(innerIdentifier, token: baseMemberAccessExpr.name)
                 return .skipChildren
             }
 
             return .skipChildren
-
         }
 
         return .visitChildren
@@ -265,10 +262,10 @@ public class FastStrategy: SyntaxVisitor, Strategy {
     private var currentFile: AbsolutePath?
 
     /**
-    * - Parameters:
-    *   - fileOrDirectory: Path of file/directory to parse.
-    *   - reporter: Reporter in which to store report.
-    */
+     * - Parameters:
+     *   - fileOrDirectory: Path of file/directory to parse.
+     *   - reporter: Reporter in which to store report.
+     */
     private func visit(fileOrDirectory: AbsolutePath) throws {
         let isDirectoryPointer = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
         guard FileManager.default.fileExists(atPath: fileOrDirectory.pathString, isDirectory: isDirectoryPointer) else {

--- a/Sources/SwiftTypeAdoptionReporter/HumanReadableReportFormatter.swift
+++ b/Sources/SwiftTypeAdoptionReporter/HumanReadableReportFormatter.swift
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 public class HumanReadableReportFormatter: ReportFormatter {
-    public init() {
-    }
+    public init() {}
 
     public func format(_ usageCounts: [String: TypeUsage]) -> String {
         let sortedUsageCounts = usageCounts.sorted(by: { $0.key < $1.key })

--- a/Sources/SwiftTypeAdoptionReporter/JSONReportFormatter.swift
+++ b/Sources/SwiftTypeAdoptionReporter/JSONReportFormatter.swift
@@ -21,8 +21,7 @@ private struct EncodableTypeUsage: Encodable {
 }
 
 public class JSONReportFormatter: ReportFormatter {
-    public init() {
-    }
+    public init() {}
 
     public func format(_ usageCounts: [String: TypeUsage]) -> String {
         let encodableTypeUsages = usageCounts.map({ name, typeUsage in

--- a/Sources/swift-type-adoption-reporter/main.swift
+++ b/Sources/swift-type-adoption-reporter/main.swift
@@ -111,4 +111,3 @@ do {
     fputs("\(error)\n", stderr)
     exit(EXIT_FAILURE)
 }
-

--- a/Tests/SwiftTypeAdoptionReporterTests/FastStrategyTests.swift
+++ b/Tests/SwiftTypeAdoptionReporterTests/FastStrategyTests.swift
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@testable import SwiftTypeAdoptionReporter
 import TSCBasic
 import XCTest
-@testable import SwiftTypeAdoptionReporter
 
 final class SwiftTypeAdoptionReporterTests: XCTestCase {
     /// *Do* count calls to constructors
@@ -194,7 +194,7 @@ final class SwiftTypeAdoptionReporterTests: XCTestCase {
     func testNamespacedFunctionCallInNonModule() {
         let sourceString = "let _ = NotMyModule.Foo()"
         let expected: [String: Int] = ["Foo": 0]
-        let moduleName =  "MyModule"
+        let moduleName = "MyModule"
         verify(expected: expected, for: sourceString, moduleName: moduleName)
     }
 
@@ -228,7 +228,7 @@ final class SwiftTypeAdoptionReporterTests: XCTestCase {
     func testNamespacedPropertyReferenceInNonModule() {
         let sourceString = "let _ = NotMyModule.Foo.bar"
         let expected: [String: Int] = ["Foo": 0]
-        let moduleName =  "MyModule"
+        let moduleName = "MyModule"
         verify(expected: expected, for: sourceString, moduleName: moduleName)
     }
 
@@ -314,11 +314,16 @@ final class SwiftTypeAdoptionReporterTests: XCTestCase {
                         file: StaticString = #file,
                         line: UInt = #line) {
         let types = types ?? expected.map({ key, _ in key })
-        assert(!types.isEmpty, "If `expected` is an empty dictionary, a list of component identifiers to search for must be passed explicitly in the `types` argument. Otherwise the test won't really be testing anything.", file: file, line: line)
+        assert(!types.isEmpty, "If `expected` is an empty dictionary, a list of component identifiers to search for must be passed explicitly in the `types` argument. Otherwise the test won't really be testing anything.", file: file, line: line) // swiftlint:disable:this line_length
 
         do {
             try withTemporaryFile { tmpFile in
-                tmpFile.fileHandle.write(sourceString.data(using: .utf8)!)
+                guard let sourceData = sourceString.data(using: .utf8) else {
+                    XCTFail("Failed to encode source string as UTF8 data")
+                    return
+                }
+
+                tmpFile.fileHandle.write(sourceData)
 
                 let strategy = FastStrategy(
                     types: types,

--- a/Tests/SwiftTypeAdoptionReporterTests/XCTestManifests.swift
+++ b/Tests/SwiftTypeAdoptionReporterTests/XCTestManifests.swift
@@ -15,9 +15,9 @@
 import XCTest
 
 #if !canImport(ObjectiveC)
-public func allTests() -> [XCTestCaseEntry] {
-    return [
-        testCase(FastStrategyTests.allTests),
-    ]
-}
+    public func allTests() -> [XCTestCaseEntry] {
+        return [
+            testCase(FastStrategyTests.allTests),
+        ]
+    }
 #endif

--- a/install_swiftformat.sh
+++ b/install_swiftformat.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Installs the SwiftFormat package.
+# Tries to get the precompiled .pkg file from Github, but if that
+# fails just recompiles from source.
+
+set -e
+
+brew update && brew install swiftformat
+
+if ! type swiftformat >/dev/null 2>&1; then
+    echo "SwiftFormat package doesn't exist. Compiling from source..." &&
+    git clone https://github.com/nicklockwood/SwiftFormat.git /tmp/SwiftFormat &&
+    cd /tmp/SwiftFormat &&
+    git submodule update --init --recursive &&
+    swift build -c release &&
+    install .build/release/swiftformat /usr/local/bin
+fi

--- a/install_swiftformat.sh
+++ b/install_swiftformat.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 # Installs the SwiftFormat package.
-# Tries to get the precompiled .pkg file from Github, but if that
-# fails just recompiles from source.
+# Tries to install from Homebrew, but if that fails just recompiles from source.
 
 set -e
 
 brew update && brew install swiftformat
 
 if ! type swiftformat > /dev/null 2>&1; then
-    echo "SwiftFormat package doesn't exist. Compiling from source..." &&
+    echo "Failed to install SwiftFormat from Homebrew. Compiling from source..." &&
     swiftformat_repo_path=$(mktemp) &&
     git clone https://github.com/nicklockwood/SwiftFormat.git $swiftformat_repo_path &&
     cd $swiftformat_repo_path &&

--- a/install_swiftformat.sh
+++ b/install_swiftformat.sh
@@ -8,7 +8,7 @@ set -e
 
 brew update && brew install swiftformat
 
-if ! type swiftformat >/dev/null 2>&1; then
+if ! type swiftformat > /dev/null 2>&1; then
     echo "SwiftFormat package doesn't exist. Compiling from source..." &&
     swiftformat_repo_path=$(mktemp) &&
     git clone https://github.com/nicklockwood/SwiftFormat.git $swiftformat_repo_path &&

--- a/install_swiftformat.sh
+++ b/install_swiftformat.sh
@@ -10,8 +10,9 @@ brew update && brew install swiftformat
 
 if ! type swiftformat >/dev/null 2>&1; then
     echo "SwiftFormat package doesn't exist. Compiling from source..." &&
-    git clone https://github.com/nicklockwood/SwiftFormat.git /tmp/SwiftFormat &&
-    cd /tmp/SwiftFormat &&
+    swiftformat_repo_path=$(mktemp) &&
+    git clone https://github.com/nicklockwood/SwiftFormat.git $swiftformat_repo_path &&
+    cd $swiftformat_repo_path &&
     git submodule update --init --recursive &&
     swift build -c release &&
     install .build/release/swiftformat /usr/local/bin

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -8,9 +8,9 @@ set -e
 
 brew update && brew install swiftlint
 
-if ! type swiftformat > /dev/null 2>&1; then
+if ! type swiftlint > /dev/null 2>&1; then
     echo "SwiftLint package doesn't exist. Compiling from source..." &&
-    swiftlint_repo_path=$(mktemp) &&
+    swiftlint_repo_path=$(mktemp swiftlint.XXXX) &&
     git clone https://github.com/realm/SwiftLint.git $swiftlint_repo_path &&
     cd $swiftlint_repo_path &&
     git submodule update --init --recursive &&

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Installs the SwiftLint package.
+# Tries to get the precompiled .pkg file from Github, but if that
+# fails just recompiles from source.
+
+set -e
+
+SWIFTLINT_PKG_PATH="/tmp/SwiftLint.pkg"
+SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.39.2/SwiftLint.pkg"
+
+curl $SWIFTLINT_PKG_URL -o $SWIFTLINT_PKG_PATH
+
+if [ -f $SWIFTLINT_PKG_PATH ]; then
+    echo "SwiftLint package exists! Installing it..."
+    sudo installer -pkg $SWIFTLINT_PKG_PATH -target /
+else
+    echo "SwiftLint package doesn't exist. Compiling from source..." &&
+    git clone https://github.com/realm/SwiftLint.git /tmp/SwiftLint &&
+    cd /tmp/SwiftLint &&
+    git submodule update --init --recursive &&
+    sudo make install
+fi

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -14,5 +14,5 @@ if ! type swiftformat > /dev/null 2>&1; then
     git clone https://github.com/realm/SwiftLint.git $swiftlint_repo_path &&
     cd $swiftlint_repo_path &&
     git submodule update --init --recursive &&
-    sudo make install
+    make install
 fi

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -6,18 +6,19 @@
 
 set -e
 
-SWIFTLINT_PKG_PATH="/tmp/SwiftLint.pkg"
+swiftlint_pkg_path=$(mktemp)
 SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.39.2/SwiftLint.pkg"
 
-curl $SWIFTLINT_PKG_URL -o $SWIFTLINT_PKG_PATH
+curl $SWIFTLINT_PKG_URL -o $swiftlint_pkg_path
 
 if [ -f $SWIFTLINT_PKG_PATH ]; then
     echo "SwiftLint package exists! Installing it..."
-    sudo installer -pkg $SWIFTLINT_PKG_PATH -target /
+    sudo installer -pkg $swiftlint_pkg_path -target /
 else
     echo "SwiftLint package doesn't exist. Compiling from source..." &&
-    git clone https://github.com/realm/SwiftLint.git /tmp/SwiftLint &&
-    cd /tmp/SwiftLint &&
+    swiftlint_repo_path=$(mktemp) &&
+    git clone https://github.com/realm/SwiftLint.git $swiftlint_repo_path &&
+    cd $swiftlint_repo_path &&
     git submodule update --init --recursive &&
     sudo make install
 fi

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 
 # Installs the SwiftLint package.
-# Tries to get the precompiled .pkg file from Github, but if that
-# fails just recompiles from source.
+# Tries to install from Homebrew, but if that fails just recompiles from source.
 
 set -e
 
 brew update && brew install swiftlint
 
 if ! type swiftlint > /dev/null 2>&1; then
-    echo "SwiftLint package doesn't exist. Compiling from source..." &&
+    echo "Failed to install SwiftLint from Homebrew. Compiling from source..." &&
     swiftlint_repo_path=$(mktemp swiftlint.XXXX) &&
     git clone https://github.com/realm/SwiftLint.git $swiftlint_repo_path &&
     cd $swiftlint_repo_path &&

--- a/install_swiftlint.sh
+++ b/install_swiftlint.sh
@@ -6,15 +6,9 @@
 
 set -e
 
-swiftlint_pkg_path=$(mktemp)
-SWIFTLINT_PKG_URL="https://github.com/realm/SwiftLint/releases/download/0.39.2/SwiftLint.pkg"
+brew update && brew install swiftlint
 
-curl $SWIFTLINT_PKG_URL -o $swiftlint_pkg_path
-
-if [ -f $SWIFTLINT_PKG_PATH ]; then
-    echo "SwiftLint package exists! Installing it..."
-    sudo installer -pkg $swiftlint_pkg_path -target /
-else
+if ! type swiftformat > /dev/null 2>&1; then
     echo "SwiftLint package doesn't exist. Compiling from source..." &&
     swiftlint_repo_path=$(mktemp) &&
     git clone https://github.com/realm/SwiftLint.git $swiftlint_repo_path &&


### PR DESCRIPTION
CI will now fail if either the linter or formatter detect any issues.

The set of enabled rules were mostly copied from Thumbtack's iOS codebase, with the exception that SwiftLint's `force_try` rule was disabled because throwing errors when a `try` goes wrong is more acceptable for command-line tools.