### PR TITLE
Improve error descriptions in output

### DIFF
--- a/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
+++ b/Sources/SwiftTypeAdoptionReporter/FastStrategy.swift
@@ -57,8 +57,15 @@ public class FastStrategy: SyntaxVisitor, Strategy {
         return typeUsages
     }
 
-    enum Error: Swift.Error {
-        case noSuchFileOrDirectory
+    enum Error: Swift.Error, CustomStringConvertible {
+        case noSuchFileOrDirectory(URL)
+
+        var description: String {
+            switch self {
+            case let .noSuchFileOrDirectory(url):
+                return "No such file or directory: \(url.path)"
+            }
+        }
     }
 
     // MARK: - SyntaxVisitor
@@ -234,7 +241,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
     private func visit(fileOrDirectory: AbsolutePath) throws {
         let isDirectoryPointer = UnsafeMutablePointer<ObjCBool>.allocate(capacity: 1)
         guard FileManager.default.fileExists(atPath: fileOrDirectory.pathString, isDirectory: isDirectoryPointer) else {
-            throw Error.noSuchFileOrDirectory
+            throw Error.noSuchFileOrDirectory(fileOrDirectory.asURL)
         }
 
         if isDirectoryPointer.pointee.boolValue {
@@ -267,7 +274,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
      */
     private func visit(file: AbsolutePath) throws {
         guard FileManager.default.fileExists(atPath: file.pathString) else {
-            throw Error.noSuchFileOrDirectory
+            throw Error.noSuchFileOrDirectory(file.asURL)
         }
 
         currentFile = file

--- a/Sources/swift-type-adoption-reporter/main.swift
+++ b/Sources/swift-type-adoption-reporter/main.swift
@@ -65,7 +65,7 @@ do {
 
     guard let types = parsedArguments.get(typesArgument) else {
         fputs("Missing types to report on.\n", stderr)
-        exit(1)
+        exit(EXIT_FAILURE)
     }
 
     let moduleName = parsedArguments.get(moduleNameArgument)
@@ -73,7 +73,7 @@ do {
 
     guard let paths = parsedArguments.get(pathsArgument) else {
         fputs("Missing paths to report on.\n", stderr)
-        exit(1)
+        exit(EXIT_FAILURE)
     }
 
     let strategy = FastStrategy(
@@ -91,19 +91,16 @@ do {
         formatter = JSONReportFormatter()
     default:
         fputs("Invalid format specified. Valid formats are \"humanReadable\" (default), \"json\"\n", stderr)
-        exit(1)
+        exit(EXIT_FAILURE)
     }
 
     let usageCounts = try strategy.findUsageCounts()
     let output = formatter.format(usageCounts)
 
     fputs("\(output)\n", stdout)
-    exit(0)
-} catch let error as ArgumentParserError {
-    fputs("\(error.description)\n", stderr)
-    exit(1)
+    exit(EXIT_SUCCESS)
 } catch {
-    fputs("\(error.localizedDescription)\n", stderr)
-    exit(1)
+    fputs("\(error)\n", stderr)
+    exit(EXIT_FAILURE)
 }
 


### PR DESCRIPTION
Provide a more helpful message for errors thrown in first-party code, and use `.description` instead of `.localizedDescription` for errors thrown in third-party code (`SwiftSyntax.ParserError`, for instance, only provides a useful `description`, not a `localizedDescription`)