### PR TITLE
Add executable and static library products

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ all: swift-type-adoption-reporter
 
 swift-type-adoption-reporter: $(SOURCES)
 	@swift build \
+		--product star \
 		-c release \
 		--disable-sandbox \
 		--build-path "$(BUILDDIR)"
@@ -23,19 +24,17 @@ swift-type-adoption-reporter: $(SOURCES)
 .PHONY: install
 install: swift-type-adoption-reporter
 	@install -d "$(bindir)" "$(libdir)"
-	@install "$(BUILDDIR)/release/swift-type-adoption-reporter" "$(bindir)"
+	@install "$(BUILDDIR)/release/star" "$(bindir)"
 	@install "$(BUILDDIR)/release/SwiftSyntax.swiftmodule" "$(libdir)"
 	@install "$(BUILDDIR)/release/libSwiftPM.dylib" "$(libdir)"
 	@install_name_tool -change \
 		"$(BUILDDIR)/x86_64-apple-macosx/release/SwiftSyntax.swiftmodule" \
 		"$(libdir)/SwiftSyntax.swiftmodule" \
-		"$(bindir)/swift-type-adoption-reporter"
-	@if [ ! -e  "$(bindir)/star" ]; then ln -s "$(bindir)/swift-type-adoption-reporter" "$(bindir)/star"; fi
+		"$(bindir)/star"
 
 .PHONY: uninstall
 uninstall:
 	@rm -rf "$(bindir)/star"
-	@rm -rf "$(bindir)/swift-type-adoption-reporter"
 	@rm -rf "$(libdir)/SwiftSyntax.swiftmodule"
 
 .PHONY: clean

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,22 @@
 import PackageDescription
 
 let package = Package(
-    name: "SwiftTypeAdoptionReporter",
+    name: "Swift Type Adoption Reporter (STAR)",
+    products: [
+        .executable(
+            name: "star",
+            targets: [
+                "swift-type-adoption-reporter",
+            ]
+        ),
+        .library(
+            name: "STAR",
+            type: .static,
+            targets: [
+                "SwiftTypeAdoptionReporter",
+            ]
+        )
+    ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-syntax.git", from: "0.50200.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Swift Type Adoption Reporter (STAR)",
+    name: "SwiftTypeAdoptionReporter",
     products: [
         .executable(
             name: "star",
@@ -32,7 +32,7 @@ let package = Package(
             targets: [
                 "SwiftTypeAdoptionReporter",
             ]
-        )
+        ),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-package-manager.git", from: "0.3.0"),

--- a/Sources/swift-type-adoption-reporter/main.swift
+++ b/Sources/swift-type-adoption-reporter/main.swift
@@ -18,7 +18,7 @@ import TSCUtility
 
 // MARK: - Arguments
 let argumentParser = ArgumentParser(
-    commandName: "swift-type-adoption-reporter",
+    commandName: "star",
     usage: "--types <types> --files <files> [--module <module name>] [--verbose]",
     overview: "Print how frequently each type has been used."
 )


### PR DESCRIPTION
The executable product was already included implicitly, but this renames the executable from `swift-type-adoption-reporter` to `star` and adds a `STAR` static library product.