### PR TITLE
Add config support for all syntax types

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,7 @@
 --disable fileHeader
 --disable isEmpty # Has the potential to auto-fix in a way that breaks the code
 --disable unusedArguments # We don't see enough value in the consistency this rule gives, and it could introduce conflicts in dependent PRs
+--disable wrapMultilineStatementBraces
 
 # These are potentially controversial.
 --disable blankLinesAroundMark # Is it a net improvement in code quality to enable this?

--- a/Sources/STARLib/FastStrategy.swift
+++ b/Sources/STARLib/FastStrategy.swift
@@ -22,8 +22,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
                 moduleName: String?,
                 includeSyntax: Set<SyntaxType>,
                 paths: [URL],
-                verbose: Bool = false)
-    {
+                verbose: Bool = false) {
         self.types = types
         self.moduleName = moduleName
         self.includeSyntax = includeSyntax
@@ -73,6 +72,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
     }
 
     // MARK: - SyntaxVisitor
+
     override public func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
         if includeSyntax.contains(.constructorCall),
             case let .identifier(identifier) = token.tokenKind,
@@ -98,8 +98,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
                     let moduleName = moduleName,
                     baseIdentifier == moduleName,
                     case let .identifier(identifier) = node.name.tokenKind,
-                    types.contains(identifier)
-                {
+                    types.contains(identifier) {
                     increment(identifier, token: node.name)
                     return .skipChildren
                 }
@@ -114,8 +113,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
                 case let .identifier(innerBaseIdentifier) = innerBaseIdentifierExpr.identifier.tokenKind,
                 innerBaseIdentifier == moduleName,
                 case let .identifier(innerIdentifier) = baseMemberAccessExpr.name.tokenKind,
-                types.contains(innerIdentifier)
-            {
+                types.contains(innerIdentifier) {
                 increment(innerIdentifier, token: baseMemberAccessExpr.name)
                 return .skipChildren
             }
@@ -195,31 +193,31 @@ public class FastStrategy: SyntaxVisitor, Strategy {
         }
     }
 
-    override public func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: UnknownSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: InOutExprSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: InOutExprSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: AssignmentExprSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: AssignmentExprSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: TypeExprSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: TypeExprSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: TypeAnnotationSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: TypeAnnotationSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: TypeInitializerClauseSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: TypeInitializerClauseSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
@@ -241,23 +239,24 @@ public class FastStrategy: SyntaxVisitor, Strategy {
         return .skipChildren
     }
 
-    override public func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: FunctionSignatureSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: AsTypePatternSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: AsTypePatternSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
-    override public func visit(_ node: AsExprSyntax) -> SyntaxVisitorContinueKind {
+    override public func visit(_: AsExprSyntax) -> SyntaxVisitorContinueKind {
         return .skipChildren
     }
 
     // MARK: - Private
+
     private let types: [String]
     private let moduleName: String?
     private let paths: [URL]
@@ -333,6 +332,7 @@ public class FastStrategy: SyntaxVisitor, Strategy {
 }
 
 // MARK: - TokenSyntax
+
 private extension TokenSyntax {
     var verboseDescription: String {
         // (Printing info about ancestor is typically more useful than printing the token syntax node itself.)

--- a/Sources/STARLib/SyntaxType.swift
+++ b/Sources/STARLib/SyntaxType.swift
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public struct TypeUsage {
-    /// Number of files this type was used in
-    let fileCount: Int
+/// Enum representing syntax conditions in which STAR may count a type.
+public enum SyntaxType: String, CaseIterable {
+    /// E.g., count `UIView()` towards UIView
+    case constructorCall
 
-    /// Number of times this type was used
-    let usageCount: Int
-}
+    /// E.g., count `UIDevice.current` towards UIDevice
+    case staticPropertyReference
 
-public protocol Strategy: AnyObject {
-    /// A set of syntax types that the strategy should include in its usage counts.
-    var includeSyntax: Set<SyntaxType> { get set }
-
-    func findUsageCounts() throws -> [String: TypeUsage]
+    /// E.g., count `class Foo: UIView` towards UIView
+    /// (includes both subclassing and protocol conformance)
+    case typeInheritance
 }

--- a/Sources/star/SyntaxType+ExpressibleByArgument.swift
+++ b/Sources/star/SyntaxType+ExpressibleByArgument.swift
@@ -12,17 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public struct TypeUsage {
-    /// Number of files this type was used in
-    let fileCount: Int
+import ArgumentParser
+import STARLib
 
-    /// Number of times this type was used
-    let usageCount: Int
-}
-
-public protocol Strategy: AnyObject {
-    /// A set of syntax types that the strategy should include in its usage counts.
-    var includeSyntax: Set<SyntaxType> { get set }
-
-    func findUsageCounts() throws -> [String: TypeUsage]
-}
+extension SyntaxType: ExpressibleByArgument {}

--- a/Sources/star/main.swift
+++ b/Sources/star/main.swift
@@ -36,6 +36,15 @@ struct MainCommand: ParsableCommand {
     var moduleName: String?
 
     @Option(
+        name: [.customLong("include-syntax")],
+        help: "Syntax conditions to include in usage counts (constructorCall, staticPropertyReference, typeInheritance)"
+    )
+    var includeSyntax: [SyntaxType] = [
+        .constructorCall,
+        .staticPropertyReference,
+    ]
+
+    @Option(
         name: .shortAndLong,
         help: "Output format (humanReadable|json)"
     )
@@ -47,12 +56,6 @@ struct MainCommand: ParsableCommand {
         help: "Paths in which to look for Swift source"
     )
     var files: [URL] = []
-
-    @Flag(
-        name: .customLong("includeTypeInheritance"),
-        help: "Include subclass and protocol conformance declarations in usage counts"
-    )
-    var includeTypeInheritance: Bool = false
 
     @Flag(
         name: .shortAndLong,
@@ -72,10 +75,10 @@ struct MainCommand: ParsableCommand {
         let strategy = FastStrategy(
             types: types,
             moduleName: moduleName,
+            includeSyntax: Set(includeSyntax),
             paths: files,
             verbose: verbose
         )
-        strategy.includeTypeInheritance = includeTypeInheritance
 
         let formatter = format.makeFormatter()
 

--- a/Tests/STARLibTests/FastStrategyTests.swift
+++ b/Tests/STARLibTests/FastStrategyTests.swift
@@ -372,14 +372,14 @@ final class SwiftTypeAdoptionReporterTests: XCTestCase {
     }
 
     // MARK: - Private
+
     private func verify(expected: [String: Int],
                         types: [String]? = nil,
                         for sourceString: String,
                         moduleName: String? = nil,
                         setUp: ((FastStrategy) -> Void)? = nil,
                         file: StaticString = #file,
-                        line: UInt = #line)
-    {
+                        line: UInt = #line) {
         let types = types ?? expected.map({ key, _ in key })
         assert(!types.isEmpty, "If `expected` is an empty dictionary, a list of component identifiers to search for must be passed explicitly in the `types` argument. Otherwise the test won't really be testing anything.", file: file, line: line) // swiftlint:disable:this line_length
 


### PR DESCRIPTION
Pass `--include-syntax` argument, followed by a list of SyntaxType
cases, to specify what conditions should be included in usage counts.
Defaults to `[.constructorCall, .staticPropertyReference]` to preserve
existing behavior.