### PR TITLE
Update to Xcode 12.5/Swift 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode12.2
+osx_image: xcode12.5
 branches:
   only:
   - master

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
+          "version": "0.4.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "2fff9fc25cdc059379b6bd309377cfab45d8520c",
+          "version": "0.50400.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ import PackageDescription
 let package = Package(
     name: "SwiftTypeAdoptionReporter",
     platforms: [
-        SupportedPlatform.macOS(.v10_12),
+        SupportedPlatform.macOS(.v11),
     ],
     products: [
         .executable(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2020 Thumbtack, Inc.
@@ -38,11 +38,11 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50300.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
+        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50400.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
         .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: [
-        .target(
+        .executableTarget(
             name: "star",
             dependencies: ["STARLib"]
         ),


### PR DESCRIPTION
Use version of SwiftSyntax that supports Swift 5.4, and update Travis configuration to run on Xcode 12.5 (which is a requirement for using Swift 5.4).