### PR TITLE
Update to swift-tools-version:5.6

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
-        "state": {
-          "branch": null,
-          "revision": "986d191f94cec88f6350056da59c2e59e83d1229",
-          "version": "0.4.3"
-        }
-      },
-      {
-        "package": "SwiftSyntax",
-        "repositoryURL": "https://github.com/apple/swift-syntax.git",
-        "state": {
-          "branch": null,
-          "revision": "75e60475d9d8fd5bbc16a12e0eaa2cb01b0c322e",
-          "version": "0.50500.0"
-        }
+  "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "986d191f94cec88f6350056da59c2e59e83d1229",
+        "version" : "0.4.3"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax.git",
+      "state" : {
+        "revision" : "0b6c22b97f8e9320bca62e82cdbee601cf37ad3f",
+        "version" : "0.50600.1"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Copyright 2020 Thumbtack, Inc.
@@ -38,8 +38,8 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50500.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
-        .package(name: "swift-argument-parser", url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/apple/swift-syntax.git", .upToNextMinor(from: "0.50600.0")), // Minor releases correspond to Swift versions (i.e., use 0.50x000.y with Swift 5.x)
+        .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "0.2.0"))
     ],
     targets: [
         .executableTarget(
@@ -49,7 +49,8 @@ let package = Package(
         .target(
             name: "STARLib",
             dependencies: [
-                "SwiftSyntax",
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftSyntaxParser", package: "swift-syntax"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),

--- a/Sources/STARLib/FastStrategy.swift
+++ b/Sources/STARLib/FastStrategy.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import SwiftSyntax
+import SwiftSyntaxParser
 
 public class FastStrategy: SyntaxVisitor, Strategy {
     public var includeSyntax: Set<SyntaxType>


### PR DESCRIPTION
### Explanation

This Pull request updates the repository to Swift 5.6 and uses the newer version of `swift-syntax`. 

### Changes

- SwiftSyntaxParser is a separate product and needs to be included as a dependency as a separate product.
- Change Package.swift to include the new tool version
- Swift 5.6 deprecated `package(name: _, url: _)` syntax. Used `.package(url: _, _)` syntax instead